### PR TITLE
fix(workflows): publish reusable workflow entrypoints

### DIFF
--- a/.github/workflows/reusable-ci-python-packages.yml
+++ b/.github/workflows/reusable-ci-python-packages.yml
@@ -1,0 +1,179 @@
+name: reusable-ci-python-packages
+
+on:
+  workflow_call:
+    inputs:
+      package_slug:
+        required: true
+        type: string
+      package_dir:
+        required: true
+        type: string
+      artifacts_dir:
+        required: true
+        type: string
+      test_python_versions:
+        required: false
+        type: string
+        default: '["3.11"]'
+      check_targets:
+        required: false
+        type: string
+        default: '["quality", "security", "docs", "api", "build", "sbom"]'
+      api_toolchain_targets:
+        required: false
+        type: string
+        default: '["api"]'
+      post_test_command:
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  ARTIFACTS_DIR: ${{ inputs.artifacts_dir }}
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  tests:
+    name: tests-${{ inputs.package_slug }}-py${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(inputs.test_python_versions) }}
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install package toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          makefile="${GITHUB_WORKSPACE}/makes/packages/$(basename '${{ inputs.package_dir }}').mk"
+          make -f "$makefile" -C "${{ inputs.package_dir }}" install
+
+      - name: Run tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          makefile="${GITHUB_WORKSPACE}/makes/packages/$(basename '${{ inputs.package_dir }}').mk"
+          make -f "$makefile" -C "${{ inputs.package_dir }}" test
+
+      - name: Run post-test validation
+        if: ${{ inputs.post_test_command != '' }}
+        shell: bash
+        run: ${{ inputs.post_test_command }}
+
+      - name: Upload test artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.package_slug }}-test-py${{ matrix.python-version }}
+          path: ${{ env.ARTIFACTS_DIR }}/test
+          if-no-files-found: ignore
+          retention-days: 14
+
+  checks:
+    name: checks-${{ inputs.package_slug }}-${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(inputs.check_targets) }}
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        if: ${{ contains(fromJson(inputs.api_toolchain_targets), matrix.target) }}
+        with:
+          node-version: "20"
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        if: ${{ contains(fromJson(inputs.api_toolchain_targets), matrix.target) }}
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install package toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          makefile="${GITHUB_WORKSPACE}/makes/packages/$(basename '${{ inputs.package_dir }}').mk"
+          make -f "$makefile" -C "${{ inputs.package_dir }}" install
+
+      - name: Run ${{ matrix.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          makefile="${GITHUB_WORKSPACE}/makes/packages/$(basename '${{ inputs.package_dir }}').mk"
+          make -f "$makefile" -C "${{ inputs.package_dir }}" ${{ matrix.target }}
+
+      - name: Upload artifacts
+        if: ${{ always() && hashFiles(format('{0}/{1}/**', env.ARTIFACTS_DIR, matrix.target)) != '' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.package_slug }}-${{ matrix.target }}
+          path: ${{ env.ARTIFACTS_DIR }}/${{ matrix.target }}
+          if-no-files-found: ignore
+          retention-days: 14
+
+  lint:
+    name: lint-${{ inputs.package_slug }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install package toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          makefile="${GITHUB_WORKSPACE}/makes/packages/$(basename '${{ inputs.package_dir }}').mk"
+          make -f "$makefile" -C "${{ inputs.package_dir }}" install
+
+      - name: Run lint
+        shell: bash
+        run: |
+          set -euo pipefail
+          makefile="${GITHUB_WORKSPACE}/makes/packages/$(basename '${{ inputs.package_dir }}').mk"
+          make -f "$makefile" -C "${{ inputs.package_dir }}" lint
+
+      - name: Upload lint artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.package_slug }}-lint
+          path: ${{ env.ARTIFACTS_DIR }}/lint
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/reusable-ci-rust-stack.yml
+++ b/.github/workflows/reusable-ci-rust-stack.yml
@@ -1,0 +1,268 @@
+name: reusable-ci-rust-stack
+
+on:
+  workflow_call:
+    inputs:
+      rust_toolchain_version:
+        required: true
+        type: string
+      enable_python_toolchain:
+        required: false
+        type: boolean
+        default: false
+      python_setup_version:
+        required: false
+        type: string
+        default: "3.11"
+      python_cache_dependency_path:
+        required: false
+        type: string
+        default: ""
+      test_python_versions:
+        required: false
+        type: string
+        default: '["3.11"]'
+      use_isolated_temp_roots:
+        required: false
+        type: boolean
+        default: false
+      security_cargo_target_dir:
+        required: false
+        type: string
+        default: ""
+      security_cargo_home:
+        required: false
+        type: string
+        default: ""
+      security_tmp_relative:
+        required: false
+        type: string
+        default: ""
+      test_cargo_target_dir:
+        required: false
+        type: string
+        default: ""
+      test_cargo_home:
+        required: false
+        type: string
+        default: ""
+      test_tmp_relative:
+        required: false
+        type: string
+        default: ""
+      install_security_tools_command:
+        required: false
+        type: string
+        default: ""
+      install_test_tools_command:
+        required: false
+        type: string
+        default: ""
+      expose_cargo_bin_path:
+        required: false
+        type: boolean
+        default: false
+      fmt_command:
+        required: false
+        type: string
+        default: make gh-fmt
+      lint_command:
+        required: false
+        type: string
+        default: make gh-lint
+      security_command:
+        required: false
+        type: string
+        default: make gh-security
+      test_command:
+        required: false
+        type: string
+        default: make gh-test
+      bijuxcli_api_guard:
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+  BIJUXCLI_API_GUARD: ${{ inputs.bijuxcli_api_guard }}
+
+jobs:
+  fmt:
+    name: Formatting
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Python
+        if: ${{ inputs.enable_python_toolchain }}
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: ${{ inputs.python_setup_version }}
+          cache: pip
+          cache-dependency-path: ${{ inputs.python_cache_dependency_path }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ inputs.rust_toolchain_version }}
+          components: rustfmt
+
+      - name: Restore the Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Run formatting checks
+        run: ${{ inputs.fmt_command }}
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Python
+        if: ${{ inputs.enable_python_toolchain }}
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: ${{ inputs.python_setup_version }}
+          cache: pip
+          cache-dependency-path: ${{ inputs.python_cache_dependency_path }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ inputs.rust_toolchain_version }}
+          components: clippy
+
+      - name: Restore the Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Run lint checks
+        run: ${{ inputs.lint_command }}
+
+  security:
+    name: Security
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      CARGO_TARGET_DIR: ${{ inputs.security_cargo_target_dir }}
+      CARGO_HOME: ${{ inputs.security_cargo_home }}
+      TMPDIR: ${{ inputs.security_tmp_relative }}
+      TMP: ${{ inputs.security_tmp_relative }}
+      TEMP: ${{ inputs.security_tmp_relative }}
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Python
+        if: ${{ inputs.enable_python_toolchain }}
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: ${{ inputs.python_setup_version }}
+          cache: pip
+          cache-dependency-path: ${{ inputs.python_cache_dependency_path }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ inputs.rust_toolchain_version }}
+
+      - name: Restore the Rust cache
+        if: ${{ !inputs.use_isolated_temp_roots }}
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Normalize temp roots to absolute workspace paths
+        if: ${{ inputs.use_isolated_temp_roots }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "TMPDIR=${GITHUB_WORKSPACE}/${TMPDIR}" >> "${GITHUB_ENV}"
+          echo "TMP=${GITHUB_WORKSPACE}/${TMP}" >> "${GITHUB_ENV}"
+          echo "TEMP=${GITHUB_WORKSPACE}/${TEMP}" >> "${GITHUB_ENV}"
+
+      - name: Prepare cache and temp roots
+        if: ${{ inputs.use_isolated_temp_roots }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${CARGO_TARGET_DIR}" "${CARGO_HOME}" "${TMPDIR}"
+
+      - name: Install security tools
+        if: ${{ inputs.install_security_tools_command != '' }}
+        run: ${{ inputs.install_security_tools_command }}
+
+      - name: Run security checks
+        run: ${{ inputs.security_command }}
+
+  test:
+    name: Tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(inputs.test_python_versions) }}
+    env:
+      CARGO_TARGET_DIR: ${{ inputs.test_cargo_target_dir }}
+      CARGO_HOME: ${{ inputs.test_cargo_home }}
+      TMPDIR: ${{ inputs.test_tmp_relative }}
+      TMP: ${{ inputs.test_tmp_relative }}
+      TEMP: ${{ inputs.test_tmp_relative }}
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Python
+        if: ${{ inputs.enable_python_toolchain }}
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: ${{ inputs.python_cache_dependency_path }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ inputs.rust_toolchain_version }}
+
+      - name: Restore the Rust cache
+        if: ${{ !inputs.use_isolated_temp_roots }}
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Normalize temp roots to absolute workspace paths
+        if: ${{ inputs.use_isolated_temp_roots }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "TMPDIR=${GITHUB_WORKSPACE}/${TMPDIR}" >> "${GITHUB_ENV}"
+          echo "TMP=${GITHUB_WORKSPACE}/${TMP}" >> "${GITHUB_ENV}"
+          echo "TEMP=${GITHUB_WORKSPACE}/${TEMP}" >> "${GITHUB_ENV}"
+
+      - name: Prepare cache and temp roots
+        if: ${{ inputs.use_isolated_temp_roots }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${CARGO_TARGET_DIR}" "${CARGO_HOME}" "${TMPDIR}"
+
+      - name: Install test tools
+        if: ${{ inputs.install_test_tools_command != '' }}
+        run: ${{ inputs.install_test_tools_command }}
+
+      - name: Expose cargo binaries
+        if: ${{ inputs.expose_cargo_bin_path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "${CARGO_HOME}/bin" >> "${GITHUB_PATH}"
+
+      - name: Run test suites
+        run: ${{ inputs.test_command }}

--- a/.github/workflows/reusable-verify-python-packages.yml
+++ b/.github/workflows/reusable-verify-python-packages.yml
@@ -1,0 +1,86 @@
+name: reusable-verify-python-packages
+
+on:
+  workflow_call:
+    inputs:
+      package_matrix_json:
+        required: true
+        type: string
+      repository_timeout_minutes:
+        required: false
+        type: number
+        default: 30
+      repository_checks_command:
+        required: false
+        type: string
+        default: make check-bijux-standard check-config-layout check-make-layout help
+      fail_on_dirty_worktree:
+        required: false
+        type: boolean
+        default: false
+      default_test_python_versions:
+        required: false
+        type: string
+        default: '["3.11"]'
+      default_check_targets:
+        required: false
+        type: string
+        default: '["quality", "security", "docs", "api", "build", "sbom"]'
+      default_api_toolchain_targets:
+        required: false
+        type: string
+        default: '["api"]'
+
+permissions:
+  contents: read
+
+jobs:
+  repository:
+    name: repository-contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.repository_timeout_minutes }}
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Run repository checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          ${{ inputs.repository_checks_command }}
+
+      - name: Confirm clean worktree after checks
+        if: ${{ inputs.fail_on_dirty_worktree }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "$(git status --short)" ]]; then
+            git status --short
+            exit 1
+          fi
+
+  package:
+    name: ${{ matrix.package_slug }}
+    needs: repository
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(inputs.package_matrix_json) }}
+    uses: ./.github/workflows/reusable-ci-python-packages.yml
+    with:
+      package_slug: ${{ matrix.package_slug }}
+      package_dir: ${{ matrix.package_dir }}
+      artifacts_dir: ${{ matrix.artifacts_dir }}
+      test_python_versions: ${{ matrix.test_python_versions || inputs.default_test_python_versions }}
+      check_targets: ${{ matrix.check_targets || inputs.default_check_targets }}
+      api_toolchain_targets: ${{ matrix.api_toolchain_targets || inputs.default_api_toolchain_targets }}
+      post_test_command: ${{ matrix.post_test_command || '' }}


### PR DESCRIPTION
## Summary
- publish reusable workflow files under .github/workflows in bijux-std
- source content remains shared/bijux-gh/workflows
- enables cross-repository workflow_call references used by consumer ci wrappers

## Notes
- canonical workflow sources stay under shared/bijux-gh/workflows
- .github/workflows copies are runtime entrypoints for GitHub reusable workflow resolution