### PR TITLE
fix(github): disable push triggers for shared release workflows

### DIFF
--- a/shared/bijux-gh/workflows/release-crates.yml
+++ b/shared/bijux-gh/workflows/release-crates.yml
@@ -4,9 +4,6 @@
 name: release-crates
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       release_tag:

--- a/shared/bijux-gh/workflows/release-ghcr.yml
+++ b/shared/bijux-gh/workflows/release-ghcr.yml
@@ -4,9 +4,6 @@
 name: release-ghcr
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       release_tag:

--- a/shared/bijux-gh/workflows/release-github.yml
+++ b/shared/bijux-gh/workflows/release-github.yml
@@ -4,9 +4,6 @@
 name: release-github
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       release_tag:

--- a/shared/bijux-gh/workflows/release-pypi.yml
+++ b/shared/bijux-gh/workflows/release-pypi.yml
@@ -4,9 +4,6 @@
 name: release-pypi
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       release_tag:


### PR DESCRIPTION
## Summary
- remove push tag triggers from shared release workflows:
  - release-github
  - release-pypi
  - release-ghcr
  - release-crates

## Why
These release workflows are intended to run via workflow_dispatch/workflow_call. Push-trigger execution creates noisy/failing runs on normal main updates.
