### PR TITLE
fix(governance): load import targets without readonly env override

### DIFF
--- a/infra/github/main-branch-protection/scripts/import_main_branch_protection.sh
+++ b/infra/github/main-branch-protection/scripts/import_main_branch_protection.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 readonly TFVARS_PATH="terraform.auto.tfvars.json"
-readonly GITHUB_OWNER="${TF_VAR_github_owner:-bijux}"
 readonly IMPORT_LOG_PATH="$(mktemp)"
 
 cleanup() {
@@ -28,7 +27,7 @@ for repo in "${repos[@]}"; do
     continue
   fi
   resource_address="github_branch_protection.main[\"${repo}\"]"
-  import_id="${GITHUB_OWNER}/${repo}:main"
+  import_id="${repo}:main"
 
   echo "Importing ${import_id}"
   if terraform import -input=false "${resource_address}" "${import_id}" >"${IMPORT_LOG_PATH}" 2>&1; then

--- a/infra/github/main-branch-protection/scripts/import_main_branch_protection.sh
+++ b/infra/github/main-branch-protection/scripts/import_main_branch_protection.sh
@@ -10,7 +10,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
-while IFS= read -r repo; do
+mapfile -t repos < <(
+  IMPORT_TFVARS_PATH="${TFVARS_PATH}" python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["IMPORT_TFVARS_PATH"], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+for repo in data.get("protected_repositories", []):
+    print(repo)
+PY
+)
+
+for repo in "${repos[@]}"; do
   if [[ -z "${repo}" ]]; then
     continue
   fi
@@ -29,15 +42,4 @@ while IFS= read -r repo; do
 
   cat "${IMPORT_LOG_PATH}" >&2
   exit 1
-done < <(
-  TFVARS_PATH="${TFVARS_PATH}" python3 - <<'PY'
-import json
-import os
-
-with open(os.environ["TFVARS_PATH"], encoding="utf-8") as handle:
-    data = json.load(handle)
-
-for repo in data.get("protected_repositories", []):
-    print(repo)
-PY
-)
+done


### PR DESCRIPTION
## Summary
- fix import script environment handoff to avoid readonly variable assignment
- switch to explicit target loading before import loop for more predictable shell behavior

## Why
The governance apply workflow failed before running imports because shell attempted to assign to readonly TFVARS_PATH.