### PR TITLE
fix(governance): allow admin bypass with preserved review gate

### DIFF
--- a/infra/github/main-branch-protection/README.md
+++ b/infra/github/main-branch-protection/README.md
@@ -10,7 +10,7 @@ Repository targets are defined in [`terraform.auto.tfvars.json`](terraform.auto.
 
 - pull request required
 - one approving review required
-- admin bypass disabled
+- admin bypass enabled for repository admins
 - force push disabled
 - branch deletion disabled
 - conversation resolution required

--- a/infra/github/main-branch-protection/main.tf
+++ b/infra/github/main-branch-protection/main.tf
@@ -10,7 +10,7 @@ resource "github_branch_protection" "main" {
   repository_id = each.value.name
   pattern       = "main"
 
-  enforce_admins                  = true
+  enforce_admins                  = var.enforce_admins
   allows_force_pushes             = false
   allows_deletions                = false
   require_conversation_resolution = true

--- a/infra/github/main-branch-protection/variables.tf
+++ b/infra/github/main-branch-protection/variables.tf
@@ -20,3 +20,9 @@ variable "required_approving_review_count" {
   type        = number
   default     = 1
 }
+
+variable "enforce_admins" {
+  description = "Whether branch protection is enforced for repository admins"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- make `enforce_admins` configurable in main branch protection Terraform
- default to `false` so admin maintainer merges are not blocked by self-approval rules
- keep `required_approving_review_count = 1` for non-admin contributors

## Validation
- configuration-only change; no runtime scripts modified
